### PR TITLE
Add minrust: false

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,11 @@ stages:
    parameters:
      minrust: 1.34.0 # integer atomics
      prefix: "noci_"
+ # test binary-focused stages (no min rust version test)
+ - template: azure/stages.yml
+   parameters:
+     minrust: false
+     prefix: "bin_"
 
 resources:
   repositories:

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -21,7 +21,7 @@ stages:
  - ${{ if ne(parameters.minrust, 'false') }}:
    # This represents the minimum Rust version supported.
    # Tests are not run as tests may require newer versions of rust.
-   - stage: "${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}"
+   - stage: ${{ format('{0}msrv', parameters.prefix) }}
      ${{ if ne(parameters.prefix, '') }}:
        displayName: "${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}"
      ${{ if eq(parameters.prefix, '') }}:

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -19,6 +19,8 @@ stages:
          name: cargo_check
          benches: ${{ parameters.benches }}
 - ${{ if ne(parameters.minrust, 'false') }}:
+ # This represents the minimum Rust version supported.
+ # Tests are not run as tests may require newer versions of rust.
   - stage: ${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}
     ${{ if ne(parameters.prefix, '') }}:
       displayName: ${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -16,6 +16,17 @@ stages:
      - template: cargo-check.yml
        parameters:
          name: cargo_check
+- ${{ if ne(parameters.minrust, 'false' }}:
+  - stage: ${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}
+    ${{ if ne(parameters.prefix, '') }}:
+      displayName: ${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}
+    ${{ if eq(parameters.prefix, '') }}:
+      displayName: ${{ format('Minimum supported Rust version: {0}', parameters.minrust) }}
+    dependsOn: []
+    jobs:
+      - template: cargo-check.yml
+        parameters:
+         rust: ${{ parameters.minrust }}
  - stage: ${{ format('{0}test', parameters.prefix) }}
    ${{ if ne(parameters.prefix, '') }}:
      displayName: ${{ format('Test suite ({0})', parameters.prefix) }}
@@ -24,8 +35,6 @@ stages:
    dependsOn: ${{ format('{0}check', parameters.prefix) }}
    jobs:
      - template: tests.yml
-       parameters:
-         minrust: ${{ parameters.minrust }}
  - stage: ${{ format('{0}style', parameters.prefix) }}
    ${{ if ne(parameters.prefix, '') }}:
      displayName: ${{ format('Style linting ({0})', parameters.prefix) }}

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -18,7 +18,7 @@ stages:
        parameters:
          name: cargo_check
          benches: ${{ parameters.benches }}
-- ${{ if ne(parameters.minrust, 'false' }}:
+- ${{ if ne(parameters.minrust, 'false') }}:
   - stage: ${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}
     ${{ if ne(parameters.prefix, '') }}:
       displayName: ${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -18,19 +18,19 @@ stages:
        parameters:
          name: cargo_check
          benches: ${{ parameters.benches }}
-- ${{ if ne(parameters.minrust, 'false') }}:
- # This represents the minimum Rust version supported.
- # Tests are not run as tests may require newer versions of rust.
-  - stage: ${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}
-    ${{ if ne(parameters.prefix, '') }}:
-      displayName: ${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}
-    ${{ if eq(parameters.prefix, '') }}:
-      displayName: ${{ format('Minimum supported Rust version: {0}', parameters.minrust) }}
-    dependsOn: []
-    jobs:
-      - template: cargo-check.yml
-        parameters:
-         rust: ${{ parameters.minrust }}
+ - ${{ if ne(parameters.minrust, 'false') }}:
+   # This represents the minimum Rust version supported.
+   # Tests are not run as tests may require newer versions of rust.
+   - stage: ${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}
+     ${{ if ne(parameters.prefix, '') }}:
+       displayName: ${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}
+     ${{ if eq(parameters.prefix, '') }}:
+       displayName: ${{ format('Minimum supported Rust version: {0}', parameters.minrust) }}
+     dependsOn: []
+     jobs:
+       - template: cargo-check.yml
+         parameters:
+          rust: ${{ parameters.minrust }}
  - stage: ${{ format('{0}test', parameters.prefix) }}
    ${{ if ne(parameters.prefix, '') }}:
      displayName: ${{ format('Test suite ({0})', parameters.prefix) }}

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -21,11 +21,11 @@ stages:
  - ${{ if ne(parameters.minrust, 'false') }}:
    # This represents the minimum Rust version supported.
    # Tests are not run as tests may require newer versions of rust.
-   - stage: ${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}
+   - stage: "${{ format('{0}check_{1}', parameters.prefix, parameters.minrust) }}"
      ${{ if ne(parameters.prefix, '') }}:
-       displayName: ${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}
+       displayName: "${{ format('Minimum supported Rust version: {1} ({0})', parameters.prefix, parameters.minrust) }}"
      ${{ if eq(parameters.prefix, '') }}:
-       displayName: ${{ format('Minimum supported Rust version: {0}', parameters.minrust) }}
+       displayName: "${{ format('Minimum supported Rust version: {0}', parameters.minrust) }}"
      dependsOn: []
      jobs:
        - template: cargo-check.yml

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -1,6 +1,4 @@
 jobs:
- # This represents the minimum Rust version supported.
- # Tests are not run as tests may require newer versions of rust.
  - template: test.yml
    parameters:
      name: cargo_test_stable

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -1,13 +1,6 @@
-parameters:
-  minrust: 1.32.0 # Rust 2018 with uniform paths
-
 jobs:
  # This represents the minimum Rust version supported.
  # Tests are not run as tests may require newer versions of rust.
- - template: cargo-check.yml
-   parameters:
-     name: minrust
-     rust: ${{ parameters.minrust }}
  - template: test.yml
    parameters:
      name: cargo_test_stable


### PR DESCRIPTION
This also moves the MSRV check out into its own stage since it's not _really_ part of the test stage.

Note that this change still leaves the default minimum Rust version as 1.32.0.

Fixes #20.