### PR TITLE
Support skipping checkout for manual override

### DIFF
--- a/azure/_setup.yml
+++ b/azure/_setup.yml
@@ -1,0 +1,22 @@
+# defaults for any parameters that aren't specified
+parameters:
+  rust: stable
+  components: []
+  targets: []
+  setup: []
+  submodules: recursive
+
+steps:
+  - template: install-rust.yml
+    parameters:
+      rust: ${{ parameters.rust }}
+      components: ${{ parameters.components }}
+      targets: ${{ parameters.targets }}
+
+  # Checkout any submodules the repository may have
+  - ${{ if ne(parameters.submodules, 'manual') }}:
+    - checkout: self
+      submodules: ${{ parameters.submodules }}
+
+  # Run any user-specific setup steps
+  - ${{ parameters.setup }}

--- a/azure/cargo-check.yml
+++ b/azure/cargo-check.yml
@@ -12,7 +12,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-  - template: install-rust.yml
+  - template: _setup.yml
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}

--- a/azure/cargo-clippy.yml
+++ b/azure/cargo-clippy.yml
@@ -13,7 +13,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - template: install-rust.yml
+    - template: _setup.yml
       parameters:
         rust: ${{ parameters.rust }}
         setup: ${{ parameters.setup }}

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -12,6 +12,9 @@ jobs:
      image: xd009642/tarpaulin:latest
      options: --security-opt seccomp=unconfined
    steps:
+     # Allow the user to define checkout: self completely manually
+     # (they would do so in parameters.setup)
+     # If they don't, we will helpfully check out all submodules recursively
      - ${{ if ne(parameters.submodules, 'manual') }}:
        - checkout: self
          submodules: ${{ parameters.submodules }}

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -12,8 +12,9 @@ jobs:
      image: xd009642/tarpaulin:latest
      options: --security-opt seccomp=unconfined
    steps:
-     - checkout: self
-       submodules: ${{ parameters.submodules }}
+     - ${{ if ne(parameters.submodules, 'manual') }}:
+       - checkout: self
+         submodules: ${{ parameters.submodules }}
      # workaround for https://github.com/MicrosoftDocs/vsts-docs/issues/4841
      # we sadly can't do this in a separate job, because:
      # https://developercommunity.visualstudio.com/content/problem/642219/setting-output-variable-when-multiple-stages-share.html

--- a/azure/install-rust.yml
+++ b/azure/install-rust.yml
@@ -54,8 +54,9 @@ steps:
     displayName: Check installed rust version
 
   # Checkout any submodules the repository may have
-  - checkout: self
-    submodules: ${{ parameters.submodules }}
+  - ${{ if ne(parameters.submodules, 'manual') }}:
+    - checkout: self
+      submodules: ${{ parameters.submodules }}
 
   # Run any user-specific setup steps
   - ${{ parameters.setup }}

--- a/azure/install-rust.yml
+++ b/azure/install-rust.yml
@@ -3,8 +3,6 @@ parameters:
   rust: stable
   components: []
   targets: []
-  setup: []
-  submodules: recursive
 
 steps:
   # Linux and macOS.
@@ -52,11 +50,3 @@ steps:
       cargo --version
       rustup --version
     displayName: Check installed rust version
-
-  # Checkout any submodules the repository may have
-  - ${{ if ne(parameters.submodules, 'manual') }}:
-    - checkout: self
-      submodules: ${{ parameters.submodules }}
-
-  # Run any user-specific setup steps
-  - ${{ parameters.setup }}

--- a/azure/rustfmt.yml
+++ b/azure/rustfmt.yml
@@ -12,7 +12,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - template: install-rust.yml
+    - template: _setup.yml
       parameters:
         rust: ${{ parameters.rust }}
         components:

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -27,7 +27,7 @@ jobs:
   pool:
     vmImage: $(vmImage)
   steps:
-  - template: install-rust.yml
+  - template: _setup.yml
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}


### PR DESCRIPTION
This enables users to manually define the entire `checkout` task for
`self` and still re-use `install-rust.yml` and `coverage.yml`.