### PR TITLE
Workaround for DevOps coercion

### DIFF
--- a/azure/cargo-check.yml
+++ b/azure/cargo-check.yml
@@ -21,7 +21,7 @@ jobs:
     displayName: Check compilation w/ default features
   - script: cargo check --all --bins --examples --tests --no-default-features
     displayName: Check compilation w/ no features
-  - ${{ if eq(parameters.all_features, 'true') }}:
+  - ${{ if eq('true', parameters.all_features) }}:
     - script: cargo check --all --bins --examples --tests --all-features
       displayName: Check compilation w/ all features
   - bash: |
@@ -36,15 +36,15 @@ jobs:
   # we only check with --all here since we don't care about the actual
   # compilation, just the dependencies + dev-dependencies resolution.
   # we _do_ include all features as it may matter though
-  - ${{ if eq(parameters.all_features, 'true') }}:
+  - ${{ if eq('true', parameters.all_features) }}:
     - script: cargo check --all --locked --all-features
       condition: and(succeeded(), eq(variables.is_locked, 'true'))
       displayName: Check that Cargo.lock is satisfiable
-  - ${{ if ne(parameters.all_features, 'true') }}:
+  - ${{ if ne('true', parameters.all_features) }}:
     - script: cargo check --all --locked
       condition: and(succeeded(), eq(variables.is_locked, 'true'))
       displayName: Check that Cargo.lock is satisfiable
 
-  - ${{ if ne(parameters.benches, 'false') }}:
+  - ${{ if ne('false', parameters.benches) }}:
     - script: cargo check --benches --all
       displayName: Check benchmarks

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -12,9 +12,9 @@ jobs:
      vmImage: ubuntu-16.04
    continueOnError: ${{ parameters.nightly }}
    container:
-     ${{ if eq(parameters.nightly, 'true') }}:
+     ${{ if eq('true', parameters.nightly) }}:
        image: xd009642/tarpaulin:latest-nightly
-     ${{ if ne(parameters.nightly, 'true') }}:
+     ${{ if ne('true', parameters.nightly) }}:
        image: xd009642/tarpaulin:latest
      options: --security-opt seccomp=unconfined
    steps:
@@ -42,11 +42,11 @@ jobs:
      - ${{ parameters.setup }}
      - script: cargo tarpaulin --features "${{ parameters.features }}" --out Xml
        displayName: Run tarpaulin
-       condition: and(succeeded(), eq(variables.has_secret, 'true'))
+       condition: and(succeeded(), eq('true', variables.has_secret))
        env:
          ${{ insert }}: ${{ parameters.envs }}
      - script: bash <(curl -s https://codecov.io/bash)
        displayName: Upload results to codecov
-       condition: and(succeeded(), eq(variables.has_secret, 'true'))
+       condition: and(succeeded(), eq('true', variables.has_secret))
        env:
          CODECOV_TOKEN: ${{ parameters.codecov_token }}

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -28,7 +28,7 @@ stages:
          benches: ${{ parameters.benches }}
          setup: ${{ parameters.setup }}
          all_features: ${{ parameters.check_all_features }}
- - ${{ if ne(parameters.minrust, 'false') }}:
+ - ${{ if ne('false', parameters.minrust) }}:
    # This represents the minimum Rust version supported.
    # Tests are not run as tests may require newer versions of rust.
    - stage: ${{ format('{0}msrv', parameters.prefix) }}

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -10,12 +10,12 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  ${{ if eq(parameters.test_ignored, 'true') }}:
+  ${{ if eq('true', parameters.test_ignored) }}:
     displayName: cargo +${{ parameters.rust }} test -- --ignored
-  ${{ if ne(parameters.test_ignored, 'true') }}:
+  ${{ if ne('true', parameters.test_ignored) }}:
     displayName: cargo +${{ parameters.rust }} test
   continueOnError: ${{ parameters.allow_fail }}
-  ${{ if eq(parameters.cross, 'true') }}:
+  ${{ if eq('true', parameters.cross) }}:
     strategy:
       matrix:
         Linux:
@@ -24,7 +24,7 @@ jobs:
           vmImage: macOS-10.14
         Windows:
           vmImage: windows-2019
-  ${{ if ne(parameters.cross, 'true') }}:
+  ${{ if ne('true', parameters.cross) }}:
     variables:
       vmImage: ubuntu-16.04
   pool:
@@ -34,22 +34,22 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
-  - ${{ if ne(parameters.single_threaded, 'true') }}:
+  - ${{ if ne('true', parameters.single_threaded) }}:
     - script: cargo test --all --features "${{ parameters.features }}"
       displayName: Run tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
-  - ${{ if eq(parameters.single_threaded, 'true') }}:
+  - ${{ if eq('true', parameters.single_threaded) }}:
     - script: cargo test --all --features "${{ parameters.features }}" -- --test-threads=1
       displayName: Run tests (single-threaded)
       env:
         ${{ insert }}: ${{ parameters.envs }}
-  - ${{ if and(eq(parameters.test_ignored, 'true'), ne(parameters.single_threaded, 'true')) }}:
+  - ${{ if and(eq('true', parameters.test_ignored), ne('true', parameters.single_threaded)) }}:
     - script: cargo test --all --features "${{ parameters.features }}" -- --ignored
       displayName: Run ignored tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
-  - ${{ if and(eq(parameters.test_ignored, 'true'), eq(parameters.single_threaded, 'true')) }}:
+  - ${{ if and(eq('true', parameters.test_ignored), eq('true', parameters.single_threaded)) }}:
     - script: cargo test --all --features "${{ parameters.features }}" -- --ignored --test-threads=1
       displayName: Run ignored tests (single-threaded)
       env:


### PR DESCRIPTION
The `eq` and `ne` functions coerce their second argument to be of the
same type as the first:
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions#eq.
If the first argument is a parameter, and it is set to `false` or `true`
(as opposed to `'false'` or `'true'`), then the second argument which
we're comparing against will be coerced to a boolean. However, since any
non-empty string is coerced to true if you had this expression:

```
${{ if eq(parameters.foo, 'false') }}:
```

Then passing `foo` as `true` would result in the condition being
considered _true_ (since `'false'` => `true == true`), and passing `foo`
as `false` would result in the condition being considered _false_ by the
same reasoning. The exact opposite of what you wanted. See also
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions#type-casting

This PR flips the operand order for every invocation of `eq` and `ne`
such that the arguments are always considered as _strings_. This fixes
the behavior observed above, since `false` is cast to `'false'` and
`true` to `'true`'.

It's stupid.