### PR TITLE
Feature/raw cargo opts

### DIFF
--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -10,6 +10,7 @@ parameters:
   check_all_features: true
   nightly_feature: ''
   test_features: ''
+  test_args_raw: ''
 
 stages:
  # the format here is so that we can have _two_ instances of this whole
@@ -58,6 +59,7 @@ stages:
          single_threaded: ${{ parameters.single_threaded }}
          nightly_feature: ${{ parameters.nightly_feature }}
          features: ${{ parameters.test_features }}
+         raw_opts: ${{ parameters.test_args_raw }}
  - stage: ${{ format('{0}style', parameters.prefix) }}
    ${{ if ne(parameters.prefix, '') }}:
      displayName: ${{ format('Style linting ({0})', parameters.prefix) }}

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -27,9 +27,10 @@ jobs:
           vmImage: macOS-10.14
         Windows:
           vmImage: windows-2019
-  ${{ if ne('true', parameters.cross) }}:
-    variables:
+  variables:
+    ${{ if ne('true', parameters.cross) }}:
       vmImage: ubuntu-16.04
+    options: ''
   pool:
     vmImage: $(vmImage)
   steps:
@@ -37,7 +38,6 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
-  - script: echo '##vso[task.setvariable variable=options] '
   # Cargo options go here
   - script: echo '##vso[task.setvariable variable=options]$(options) --all'
   - ${{ if eq(true, parameters.features)}}:
@@ -52,12 +52,12 @@ jobs:
     - script: echo '##vso[task.setvariable variable=options]$(options) --ignored'
   # Run tests with the given options
   - ${{ if eq(true, parameters.raw_opts) }}:
-    - script: cargo test ${{ parameters.raw_opts }}
+    - bash: cargo test ${{ parameters.raw_opts }}
       displayName: Run tests (with... ${{ parameters.raw_opts }})
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if ne(true, parameters.raw_opts) }}:
-    - script: cargo test $(options)
+    - bash: cargo test $(options)
       displayName: Run tests
       env:
         ${{ insert }}: ${{ parameters.envs }}

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -7,6 +7,9 @@ parameters:
   test_ignored: false
   single_threaded: false
   features: '' # empty feature list is == default
+  raw_opts: ''
+
+
 
 jobs:
 - job: ${{ parameters.name }}
@@ -34,23 +37,28 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
-  - ${{ if ne('true', parameters.single_threaded) }}:
-    - script: cargo test --all --features "${{ parameters.features }}"
+  - script: echo '##vso[task.setvariable variable=options] '
+  # Cargo options go here
+  - script: echo '##vso[task.setvariable variable=options]$(options) --all'
+  - ${{ if eq(true, parameters.features)}}:
+    - script: echo '##vso[task.setvariable variable=options]$(options) --features "${{ parameters.features }}"'
+  # Add any additional conditional cargo options to this check
+  - ${{ if or(eq(true, parameters.single_threaded), eq(true, parameters.test_ignored))}}:
+    - script: echo '##vso[task.setvariable variable=options]$(options) --'
+  # Options passed to libtest go here
+  - ${{ if eq(true, parameters.single_threaded) }}:
+    - script: echo '##vso[task.setvariable variable=options]$(options) --test_threads=1'
+  - ${{ if eq(true, parameters.test_ignored)}}:
+    - script: echo '##vso[task.setvariable variable=options]$(options) --ignored'
+  # Run tests with the given options
+  - ${{ if eq(true, parameters.raw_opts) }}:
+    - script: cargo test ${{ parameters.raw_opts }}
+      displayName: Run tests (with... ${{ parameters.raw_opts }})
+      env:
+        ${{ insert }}: ${{ parameters.envs }}
+  - ${{ if ne(true, parameters.raw_opts) }}:
+    - script: cargo test $(options)
       displayName: Run tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
-  - ${{ if eq('true', parameters.single_threaded) }}:
-    - script: cargo test --all --features "${{ parameters.features }}" -- --test-threads=1
-      displayName: Run tests (single-threaded)
-      env:
-        ${{ insert }}: ${{ parameters.envs }}
-  - ${{ if and(eq('true', parameters.test_ignored), ne('true', parameters.single_threaded)) }}:
-    - script: cargo test --all --features "${{ parameters.features }}" -- --ignored
-      displayName: Run ignored tests
-      env:
-        ${{ insert }}: ${{ parameters.envs }}
-  - ${{ if and(eq('true', parameters.test_ignored), eq('true', parameters.single_threaded)) }}:
-    - script: cargo test --all --features "${{ parameters.features }}" -- --ignored --test-threads=1
-      displayName: Run ignored tests (single-threaded)
-      env:
-        ${{ insert }}: ${{ parameters.envs }}
+

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -42,7 +42,7 @@ jobs:
   - script: echo '##vso[task.setvariable variable=options]$(options) --all'
   - ${{ if eq(true, parameters.features)}}:
     - script: echo '##vso[task.setvariable variable=options]$(options) --features "${{ parameters.features }}"'
-  # Add any additional conditional cargo options to this check
+  # Add any additional conditional libtest options to this check
   - ${{ if or(eq(true, parameters.single_threaded), eq(true, parameters.test_ignored))}}:
     - script: echo '##vso[task.setvariable variable=options]$(options) --'
   # Options passed to libtest go here

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -9,8 +9,6 @@ parameters:
   features: '' # empty feature list is == default
   raw_opts: ''
 
-
-
 jobs:
 - job: ${{ parameters.name }}
   ${{ if eq('true', parameters.test_ignored) }}:

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -47,7 +47,7 @@ jobs:
     - script: echo '##vso[task.setvariable variable=options]$(options) --'
   # Options passed to libtest go here
   - ${{ if eq(true, parameters.single_threaded) }}:
-    - script: echo '##vso[task.setvariable variable=options]$(options) --test_threads=1'
+    - script: echo '##vso[task.setvariable variable=options]$(options) --test-threads=1'
   - ${{ if eq(true, parameters.test_ignored)}}:
     - script: echo '##vso[task.setvariable variable=options]$(options) --ignored'
   # Run tests with the given options

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -5,6 +5,7 @@ parameters:
   single_threaded: false
   nightly_feature: ''
   features: ''
+  raw_opts: ''
 
 jobs:
  - template: test.yml
@@ -16,6 +17,7 @@ jobs:
      test_ignored: ${{ parameters.test_ignored }}
      single_threaded: ${{ parameters.single_threaded }}
      features: ${{ parameters.features }}
+     raw_opts: ${{ parameters.raw_opts }}
  - template: test.yml
    parameters:
      name: cargo_test_beta
@@ -25,6 +27,7 @@ jobs:
      test_ignored: ${{ parameters.test_ignored }}
      single_threaded: ${{ parameters.single_threaded }}
      features: ${{ parameters.features }}
+     raw_opts: ${{ parameters.raw_opts }}
  - template: test.yml
    parameters:
      name: cargo_test_nightly
@@ -35,3 +38,4 @@ jobs:
      test_ignored: ${{ parameters.test_ignored }}
      single_threaded: ${{ parameters.single_threaded }}
      features: "${{ parameters.features }},${{ parameters.nightly_feature }}"
+     raw_opts: ${{ parameters.raw_opts }}


### PR DESCRIPTION
Adds a parameter 'test_args_raw' that allows users to pass raw args/options to cargo/libtest.

It also refactors how conditional checks are handled: rather than checking all combinations of bools for each endpoint, it builds up a variable, which is passed to `cargo test`. This makes the logic easier to extend and reason about.

Finally, the various `eq` / `ne` conditionals have their syntax altered:
* Changed 'true' (string) => true (bool)
* Swapped arg positions so the correct type coercion [occurs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#eq)