### PR TITLE
Support running service containers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,6 @@ stages:
 resources:
   containers:
   - container: any
-    image: ubuntu:16.04
+    image: alpine:latest
     ports:
-      - 22
+      - 2222:22

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,8 @@ stages:
      test_features: ci
      envs:
        ENV_IS_SET: true
+     services:
+       test_service: any
      setup:
        - script: touch src/setup.rs
  # should work without code coverage token
@@ -17,6 +19,8 @@ stages:
      test_features: ci
      envs:
        ENV_IS_SET: true
+     services:
+       test_service: any
      setup:
        - script: touch src/setup.rs
  # also test with various other configuration changes
@@ -33,6 +37,8 @@ stages:
      check_all_features: false
      envs:
        ENV_IS_SET: true
+     services:
+       test_service: any
      setup:
        - script: touch src/setup.rs
  # test binary-focused stages (no min rust version test)
@@ -43,5 +49,12 @@ stages:
      test_features: ci
      envs:
        ENV_IS_SET: true
+     services:
+       test_service: any
      setup:
        - script: touch src/setup.rs
+
+resources:
+  containers:
+  - container: any
+    image: ubuntu:16.04

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,6 @@ stages:
 resources:
   containers:
   - container: any
-    image: alpine:latest
+    image: panubo/sshd
     ports:
       - 2222:22

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,3 +58,5 @@ resources:
   containers:
   - container: any
     image: ubuntu:16.04
+    ports:
+      - 22

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -1,5 +1,6 @@
 parameters:
   envs: {}
+  services: {}
   setup: []
   submodules: recursive
   nightly: false
@@ -10,6 +11,14 @@ jobs:
    displayName: tarpaulin
    pool:
      vmImage: ubuntu-16.04
+   # this is sad: we need to spin up the service containers even if the token
+   # isn't set, since we can't set a service in a particular script step.
+   # once the fix to
+   # https://developercommunity.visualstudio.com/content/problem/642219/setting-output-variable-when-multiple-stages-share.html
+   # lands everywhere, we can move to multiple jobs instead, and then only the
+   # (conditional) second job will have this service.
+   services:
+     ${{ insert }}: ${{ parameters.services }}
    continueOnError: ${{ parameters.nightly }}
    container:
      ${{ if eq('true', parameters.nightly) }}:

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -3,6 +3,7 @@ parameters:
   benches: false
   prefix: ''
   envs: {}
+  services: {}
   setup: []
   test_ignored: false
   single_threaded: false
@@ -53,6 +54,7 @@ stages:
      - template: tests.yml
        parameters:
          envs: ${{ parameters.envs }}
+         services: ${{ parameters.services }}
          setup: ${{ parameters.setup }}
          test_ignored: ${{ parameters.test_ignored }}
          single_threaded: ${{ parameters.single_threaded }}
@@ -80,6 +82,7 @@ stages:
           parameters:
             codecov_token: ${{ parameters.codecov_token }}
             envs: ${{ parameters.envs }}
+            services: ${{ parameters.services }}
             setup: ${{ parameters.setup }}
             nightly: ${{ parameters.nightly_coverage }}
             features: ${{ parameters.test_features }}

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -7,6 +7,7 @@ parameters:
   test_ignored: false
   single_threaded: false
   features: '' # empty feature list is == default
+  services: {}
 
 jobs:
 - job: ${{ parameters.name }}
@@ -29,6 +30,8 @@ jobs:
       vmImage: ubuntu-16.04
   pool:
     vmImage: $(vmImage)
+  services:
+    ${{ insert }}: ${{ parameters.services }}
   steps:
   - template: _setup.yml
     parameters:

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -5,6 +5,7 @@ parameters:
   single_threaded: false
   nightly_feature: ''
   features: ''
+  services: {}
 
 jobs:
  - template: test.yml
@@ -12,6 +13,7 @@ jobs:
      name: cargo_test_stable
      cross: true # also test on Windows and macOS
      envs: ${{ parameters.envs }}
+     services: ${{ parameters.services }}
      setup: ${{ parameters.setup }}
      test_ignored: ${{ parameters.test_ignored }}
      single_threaded: ${{ parameters.single_threaded }}
@@ -21,6 +23,7 @@ jobs:
      name: cargo_test_beta
      rust: beta
      envs: ${{ parameters.envs }}
+     services: ${{ parameters.services }}
      setup: ${{ parameters.setup }}
      test_ignored: ${{ parameters.test_ignored }}
      single_threaded: ${{ parameters.single_threaded }}
@@ -31,6 +34,7 @@ jobs:
      rust: nightly
      allow_fail: true
      envs: ${{ parameters.envs }}
+     services: ${{ parameters.services }}
      setup: ${{ parameters.setup }}
      test_ignored: ${{ parameters.test_ignored }}
      single_threaded: ${{ parameters.single_threaded }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,6 +159,21 @@ stages:
        ENV_B: $(PIPELINE_VAR)
 ```
 
+### Service containers
+
+```yaml
+stages:
+ - template: azure/stages.yml@templates
+   parameters:
+     services:
+       <hostname>: <container>
+```
+
+If you tests require particular [service
+containers](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/service-containers?view=azure-devops&tabs=yaml)
+to be running, you can define these using the `services` parameter. The
+given service containers will be started in whenever your tests are run.
+
 ### Additional setup steps
 
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,7 +166,7 @@ stages:
  - template: azure/stages.yml@templates
    parameters:
      services:
-       <hostname>: <container>
+       <name>: <container>
 ```
 
 If you tests require particular [service

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -175,6 +175,8 @@ parameters:
   features: <string> = ''
   envs:
     NAME: value
+  services:
+    HOSTNAME: container
   setup:
     - task
 ```
@@ -192,6 +194,9 @@ set `test_ignored: true`. To run tests with
 [`--test-threads=1`](https://doc.rust-lang.org/book/ch11-02-running-tests.html#running-tests-in-parallel-or-consecutively),
 set `single_threaded: true`. To run tests with particular features
 enabled, pass `features: "feat1,feat2,subcrate/feat3"`.
+To spin up additional [service
+containers](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/service-containers?view=azure-devops&tabs=yaml),
+pass them in `services`.
 
 ### Style
 
@@ -235,8 +240,10 @@ and upload the coverage test results to
 `codecov_token` that includes the codecov.io upload token (see the
 [setup instructions](setup.md#code-coverage)). You can also pass the
 parameter `envs: {...}` to pass [environment
-variables](configuration.md#environment-variables), and `setup: [...]`
-to run [additional setup
+variables](configuration.md#environment-variables), `services: {...}` to
+run additional [service
+containers](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/service-containers?view=azure-devops&tabs=yaml),
+and `setup: [...]` to run [additional setup
 steps](configuration.md#additional-setup-steps).
 
 By default, your pipeline will test against the stable Rust version

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -176,7 +176,7 @@ parameters:
   envs:
     NAME: value
   services:
-    HOSTNAME: container
+    NAME: container
   setup:
     - task
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ fn test_must_exist() {
 #[test]
 fn test_service_running() {
     use std::net::ToSocketAddrs;
-    let mut addrs_iter = "127.0.0.1:22".to_socket_addrs().unwrap();
+    let mut addrs_iter = "127.0.0.1:2222".to_socket_addrs().unwrap();
     let addr = addrs_iter.next().unwrap();
     std::net::TcpStream::connect(addr).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,9 @@ fn test_must_exist() {
 #[test]
 fn test_service_running() {
     use std::net::ToSocketAddrs;
-    let mut addrs_iter = "test_service:22".to_socket_addrs().unwrap();
-    assert_ne!(addrs_iter.next(), None);
+    let mut addrs_iter = "127.0.0.1:22".to_socket_addrs().unwrap();
+    let addr = addrs_iter.next().unwrap();
+    std::net::TcpStream::connect(addr).unwrap();
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,14 @@ fn test_must_exist() {
 
 #[cfg(test)]
 #[test]
+fn test_service_running() {
+    use std::net::ToSocketAddrs;
+    let mut addrs_iter = "test_service:22".to_socket_addrs().unwrap();
+    assert_ne!(addrs_iter.next(), None);
+}
+
+#[cfg(test)]
+#[test]
 fn require_setup_file() {
     include_str!("setup.rs");
 }


### PR DESCRIPTION
This is really handy for projects that need services running for tests (like the `imap` crate which needs a mock IMAP server running).