### PR TITLE
Tidy up handling of features

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,7 @@ stages:
  - template: azure/stages.yml
    parameters:
      minrust: false
+     codecov_token: $(CODECOV_TOKEN_SECRET)
      prefix: "nofeat_"
      envs:
        ENV_IS_SET: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,3 +58,13 @@ stages:
        ENV_IS_SET: true
      setup:
        - script: touch src/setup.rs
+ # test no features
+ - template: azure/stages.yml
+   parameters:
+     minrust: false
+     prefix: "nofeat_"
+     envs:
+       ENV_IS_SET: true
+       ALLOW_NO_FEATURES: true
+     setup:
+       - script: touch src/setup.rs

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -50,7 +50,7 @@ jobs:
      # Sadly we don't have a way of communicating the condition on has_secret
      - ${{ parameters.setup }}
      # Determine what features to use
-     - bash: "if [[ -n $FEATURES ]]; then echo '##vso[task.setvariable variable=features]'; else echo '##vso[task.setvariable variable=features]--features \"$FEATURES\"'; fi"
+     - bash: "if [[ -n $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
        name: features
        displayName: Determine feature flags
        env:

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -50,7 +50,7 @@ jobs:
      # Sadly we don't have a way of communicating the condition on has_secret
      - ${{ parameters.setup }}
      # Determine what features to use
-     - bash: "if [[ -n $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
+     - bash: "if [[ -z $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
        name: features
        displayName: Determine feature flags
        env:

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -4,7 +4,7 @@ parameters:
   setup: []
   submodules: recursive
   nightly: false
-  features: '' # empty feature list is == default
+  features: []
 
 jobs:
  - job: tarpaulin
@@ -49,7 +49,13 @@ jobs:
      # Run any user-specific setup steps
      # Sadly we don't have a way of communicating the condition on has_secret
      - ${{ parameters.setup }}
-     - script: cargo tarpaulin --features "${{ parameters.features }}" --out Xml
+     # Determine what features to use
+     - bash: "if [[ -n $FEATURES ]]; then echo '##vso[task.setvariable variable=features]'; else echo '##vso[task.setvariable variable=features]--features \"$FEATURES\"'; fi"
+       name: features
+       displayName: Determine feature flags
+       env:
+         FEATURES: ${{ join(",", parameters.features) }}
+     - script: cargo tarpaulin $(variables.features) --out Xml
        displayName: Run tarpaulin
        condition: and(succeeded(), eq('true', variables.has_secret))
        env:

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -54,7 +54,7 @@ jobs:
        name: features
        displayName: Determine feature flags
        env:
-         FEATURES: ${{ join(",", parameters.features) }}
+         FEATURES: ${{ join(',', parameters.features) }}
      - script: cargo tarpaulin $(variables.features) --out Xml
        displayName: Run tarpaulin
        condition: and(succeeded(), eq('true', variables.has_secret))

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -50,7 +50,7 @@ jobs:
      # Sadly we don't have a way of communicating the condition on has_secret
      - ${{ parameters.setup }}
      # Determine what features to use
-     - bash: "if [[ -z $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
+     - bash: "if [[ -z $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features \\\"$FEATURES\\\"\"; fi"
        name: features
        displayName: Determine feature flags
        env:

--- a/azure/coverage.yml
+++ b/azure/coverage.yml
@@ -55,7 +55,7 @@ jobs:
        displayName: Determine feature flags
        env:
          FEATURES: ${{ join(',', parameters.features) }}
-     - script: cargo tarpaulin $(variables.features) --out Xml
+     - script: cargo tarpaulin $(features) --out Xml
        displayName: Run tarpaulin
        condition: and(succeeded(), eq('true', variables.has_secret))
        env:

--- a/azure/nightly-stages.yml
+++ b/azure/nightly-stages.yml
@@ -6,7 +6,7 @@ parameters:
   test_ignored: false
   single_threaded: false
   check_all_features: true
-  test_features: ''
+  test_features: []
 
 stages:
  # the format here is so that we can have _two_ instances of this whole

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -8,8 +8,8 @@ parameters:
   single_threaded: false
   nightly_coverage: false
   check_all_features: true
-  nightly_feature: ''
-  test_features: ''
+  nightly_features: []
+  test_features: []
 
 stages:
  # the format here is so that we can have _two_ instances of this whole
@@ -56,7 +56,7 @@ stages:
          setup: ${{ parameters.setup }}
          test_ignored: ${{ parameters.test_ignored }}
          single_threaded: ${{ parameters.single_threaded }}
-         nightly_feature: ${{ parameters.nightly_feature }}
+         nightly_features: ${{ parameters.nightly_features }}
          features: ${{ parameters.test_features }}
  - stage: ${{ format('{0}style', parameters.prefix) }}
    ${{ if ne(parameters.prefix, '') }}:

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -37,7 +37,7 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
-  - bash: "if [[ -z $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
+  - bash: "if [[ -z $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features \\\"$FEATURES\\\"\"; fi"
     name: features
     displayName: Determine feature flags
     env:

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -37,7 +37,7 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
-  - bash: "if [[ -n $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
+  - bash: "if [[ -z $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
     name: features
     displayName: Determine feature flags
     env:

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -37,7 +37,7 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
-  - bash: "if [[ -n $FEATURES ]]; then echo '##vso[task.setvariable variable=features]'; else echo '##vso[task.setvariable variable=features]--features \"$FEATURES\"'; fi"
+  - bash: "if [[ -n $FEATURES ]]; then echo \"##vso[task.setvariable variable=features]\"; else echo \"##vso[task.setvariable variable=features]--features '$FEATURES'\"; fi"
     name: features
     displayName: Determine feature flags
     env:

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -6,7 +6,7 @@ parameters:
   setup: []
   test_ignored: false
   single_threaded: false
-  features: '' # empty feature list is == default
+  features: []
   services: {}
 
 jobs:
@@ -37,23 +37,28 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
+  - bash: "if [[ -n $FEATURES ]]; then echo '##vso[task.setvariable variable=features]'; else echo '##vso[task.setvariable variable=features]--features \"$FEATURES\"'; fi"
+    name: features
+    displayName: Determine feature flags
+    env:
+      FEATURES: ${{ join(",", parameters.features) }}
   - ${{ if ne('true', parameters.single_threaded) }}:
-    - script: cargo test --all --features "${{ parameters.features }}"
+    - script: cargo test --all $(variables.features)
       displayName: Run tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if eq('true', parameters.single_threaded) }}:
-    - script: cargo test --all --features "${{ parameters.features }}" -- --test-threads=1
+    - script: cargo test --all $(variables.features) -- --test-threads=1
       displayName: Run tests (single-threaded)
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if and(eq('true', parameters.test_ignored), ne('true', parameters.single_threaded)) }}:
-    - script: cargo test --all --features "${{ parameters.features }}" -- --ignored
+    - script: cargo test --all $(variables.features) -- --ignored
       displayName: Run ignored tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if and(eq('true', parameters.test_ignored), eq('true', parameters.single_threaded)) }}:
-    - script: cargo test --all --features "${{ parameters.features }}" -- --ignored --test-threads=1
+    - script: cargo test --all $(variables.features) -- --ignored --test-threads=1
       displayName: Run ignored tests (single-threaded)
       env:
         ${{ insert }}: ${{ parameters.envs }}

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -41,7 +41,7 @@ jobs:
     name: features
     displayName: Determine feature flags
     env:
-      FEATURES: ${{ join(",", parameters.features) }}
+      FEATURES: ${{ join(',', parameters.features) }}
   - ${{ if ne('true', parameters.single_threaded) }}:
     - script: cargo test --all $(variables.features)
       displayName: Run tests

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -43,22 +43,22 @@ jobs:
     env:
       FEATURES: ${{ join(',', parameters.features) }}
   - ${{ if ne('true', parameters.single_threaded) }}:
-    - script: cargo test --all $(variables.features)
+    - script: cargo test --all $(features)
       displayName: Run tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if eq('true', parameters.single_threaded) }}:
-    - script: cargo test --all $(variables.features) -- --test-threads=1
+    - script: cargo test --all $(features) -- --test-threads=1
       displayName: Run tests (single-threaded)
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if and(eq('true', parameters.test_ignored), ne('true', parameters.single_threaded)) }}:
-    - script: cargo test --all $(variables.features) -- --ignored
+    - script: cargo test --all $(features) -- --ignored
       displayName: Run ignored tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if and(eq('true', parameters.test_ignored), eq('true', parameters.single_threaded)) }}:
-    - script: cargo test --all $(variables.features) -- --ignored --test-threads=1
+    - script: cargo test --all $(features) -- --ignored --test-threads=1
       displayName: Run ignored tests (single-threaded)
       env:
         ${{ insert }}: ${{ parameters.envs }}

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -3,8 +3,8 @@ parameters:
   setup: []
   test_ignored: false
   single_threaded: false
-  nightly_feature: ''
-  features: ''
+  nightly_features: []
+  features: []
 
 jobs:
  - template: test.yml
@@ -34,4 +34,6 @@ jobs:
      setup: ${{ parameters.setup }}
      test_ignored: ${{ parameters.test_ignored }}
      single_threaded: ${{ parameters.single_threaded }}
-     features: "${{ parameters.features }},${{ parameters.nightly_feature }}"
+     features:
+       - ${{ parameters.features }}
+       - ${{ parameters.nightly_feature }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,13 +72,13 @@ Set this parameter to `true` to also run tests [marked with
 stages:
  - template: azure/stages.yml@templates
    parameters:
-     test_features: <string> = ''
-     nightly_feature: <string> = ''
+     test_features: <[string]> = []
+     nightly_features: <[string]> = []
 ```
 
 If this parameter is set, it is passed along with `--features` to `cargo
 test`. This is useful if you have non-default features that you'd like
-to test on CI. You can also set `nightly_feature` which will only be
+to test on CI. You can also set `nightly_features` which will only be
 included when run on nightly, though do note that since nightly tests
 are always allowed to fail, you will only see yellow CI if these tests
 fail. If you have features like this, you _probably_ also want to
@@ -90,7 +90,7 @@ features as `subcrate/feature` as described in [this
 issue](https://github.com/rust-lang/cargo/issues/5015). There is not
 currently a way to disabling default features for CI tests.
 
-**`nightly_feature is not supported (or needed) on `nightly-stages.yml`.**
+**`nightly_features is not supported (or needed) on `nightly-stages.yml`.**
 
 ### Single-threaded test execution
 

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -158,8 +158,8 @@ You can pass the parameter `envs: {...}` to pass [environment
 variables](configuration.md#environment-variables), and `setup: [...]`
 to run [additional setup
 steps](configuration.md#additional-setup-steps). You can also pass
-`features` and/or `nightly_feature` to include additional cargo features
-when running the tests. `nightly_feature` will only be included on runs
+`features` and/or `nightly_features` to include additional cargo features
+when running the tests. `nightly_features` will only be included on runs
 with the nightly compiler. See the [test docs](#test) for details.
 
 ### Test
@@ -172,7 +172,7 @@ parameters:
   allow_fail: <bool> = false
   test_ignored: <bool> = false
   single_threaded: <bool> = false
-  features: <string> = ''
+  features: <[string]> = []
   envs:
     NAME: value
   services:
@@ -193,7 +193,7 @@ nightly versions of the compiler. To run tests [marked with
 set `test_ignored: true`. To run tests with
 [`--test-threads=1`](https://doc.rust-lang.org/book/ch11-02-running-tests.html#running-tests-in-parallel-or-consecutively),
 set `single_threaded: true`. To run tests with particular features
-enabled, pass `features: "feat1,feat2,subcrate/feat3"`.
+enabled, pass `features: [feat1,feat2,subcrate/feat3]`.
 To spin up additional [service
 containers](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/service-containers?view=azure-devops&tabs=yaml),
 pass them in `services` (though note that these will generally only work

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@ fn require_env() {
 
 #[cfg(all(test, not(feature = "ci")))]
 fn must_exist() {
-    panic!("ci feature was not enabled for test run");
+    if !std::env::var("ALLOW_NO_FEATURES").is_ok() {
+        panic!("ci feature was not enabled for test run");
+    }
 }
 
 #[cfg(all(test, feature = "ci"))]


### PR DESCRIPTION
This patch changes feature handling such that:

 - All feature lists are passed as lists, not strings
 - If there are no features, `--features` is not passed (needed to fix #64)
 - If only one of `test_features` and `nightly_features` is passed, there is no leading/trailing comma
 - `nightly_features` now has an `s` at the end like all the other feature lists

Note that this change is not quite backwards compatible -- things that were previously strings are now lists. That said, the old format _may_ still work (I haven't tested) since we're just producing a string at the end anyway. This also renames `nightly_feature` to `nightly_features`, which is _definitely_ not backwards compatible.

Note also that the included test doesn't actually fail. `--features ,` is apparently still totally legal. #64 happens only because `--features` isn't allowed in a workspace, not because `--features ,` specifically isn't allowed. But I figured we should tidy up the handling of the latter anyway.