### PR TITLE
Expose cross parameter in root template

### DIFF
--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -2,6 +2,7 @@ parameters:
   minrust: 1.32.0 # Rust 2018 with uniform paths
   benches: false
   prefix: ''
+  cross: true
   envs: {}
   setup: []
   test_ignored: false
@@ -52,6 +53,7 @@ stages:
    jobs:
      - template: tests.yml
        parameters:
+         cross: ${{ parameters.cross }}
          envs: ${{ parameters.envs }}
          setup: ${{ parameters.setup }}
          test_ignored: ${{ parameters.test_ignored }}

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -1,4 +1,5 @@
 parameters:
+  cross: true # per default also test on Windows and macOS
   envs: {}
   setup: []
   test_ignored: false
@@ -10,7 +11,7 @@ jobs:
  - template: test.yml
    parameters:
      name: cargo_test_stable
-     cross: true # also test on Windows and macOS
+     cross: ${{ parameters.cross }}
      envs: ${{ parameters.envs }}
      setup: ${{ parameters.setup }}
      test_ignored: ${{ parameters.test_ignored }}


### PR DESCRIPTION
In my first experiments with `azure-pipelines` I needed to disable cross platform testing as my crate only builds on Linux. I found the `cross` parameter in `azure/test.yml` but was surprised that it was not usable from the root template.

I get that the single templates are designed to be reusable and the root template just provides a common baseline but I think that the common case of "Linux only" should be supported here. The new `cross` parameter in the root template defaults to `true` so the default behavior is unchanged.

If this is not desired, I can close this PR and build my own template as described in the docs.