### PR TITLE
Replaced deprecated cargo `--all` flag with `--workspace` flag

### DIFF
--- a/azure/cargo-check.yml
+++ b/azure/cargo-check.yml
@@ -29,14 +29,12 @@ jobs:
   - script: cargo check --locked
     condition: and(succeeded(), eq(variables.is_locked, 'true'))
     displayName: Check that Cargo.lock is satisfiable
-  - script: cargo check --all --bins --examples --tests
+  - script: cargo check --workspace --bins --examples --tests
     displayName: Check compilation w/ default features
-  - script: cargo check --all --bins --examples --tests --no-default-features
-    displayName: Check compilation w/ no features
   - ${{ if eq('true', parameters.all_features) }}:
-    - script: cargo check --all --bins --examples --tests --all-features
+    - script: cargo check --workspace --bins --examples --tests --all-features
       displayName: Check compilation w/ all features
 
   - ${{ if ne('false', parameters.benches) }}:
-    - script: cargo check --benches --all
+    - script: cargo check --benches --workspace
       displayName: Check benchmarks

--- a/azure/cargo-clippy.yml
+++ b/azure/cargo-clippy.yml
@@ -19,5 +19,5 @@ jobs:
         setup: ${{ parameters.setup }}
         components:
           - clippy
-    - script: cargo clippy --all 
+    - script: cargo clippy --workspace 
       displayName: Run clippy

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -43,22 +43,22 @@ jobs:
     env:
       FEATURES: ${{ join(',', parameters.features) }}
   - ${{ if ne('true', parameters.single_threaded) }}:
-    - script: cargo test --all $(features)
+    - script: cargo test --workspace $(features)
       displayName: Run tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if eq('true', parameters.single_threaded) }}:
-    - script: cargo test --all $(features) -- --test-threads=1
+    - script: cargo test --workspace $(features) -- --test-threads=1
       displayName: Run tests (single-threaded)
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if and(eq('true', parameters.test_ignored), ne('true', parameters.single_threaded)) }}:
-    - script: cargo test --all $(features) -- --ignored
+    - script: cargo test --workspace $(features) -- --ignored
       displayName: Run ignored tests
       env:
         ${{ insert }}: ${{ parameters.envs }}
   - ${{ if and(eq('true', parameters.test_ignored), eq('true', parameters.single_threaded)) }}:
-    - script: cargo test --all $(features) -- --ignored --test-threads=1
+    - script: cargo test --workspace $(features) -- --ignored --test-threads=1
       displayName: Run ignored tests (single-threaded)
       env:
         ${{ insert }}: ${{ parameters.envs }}


### PR DESCRIPTION
Cargo check -h shows that the --all flag has been depreacated and replaced with the --workspace flag. Also https://github.com/rust-lang/cargo/issues/5015 shows hat the --no-default-features is currently broken so we thought that this part of the pipeline should be deleted (at least until this gets fixed) from the `cargo-check.yml` file.