### PR TITLE
[default.yml] Run user setup step for lint jobs

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -24,6 +24,8 @@ jobs:
          components:
            - rustfmt
            - clippy
+     # Run any user-specific setup steps
+     - ${{ parameters.setup }}
      - script: cargo fmt --all -- --check
        displayName: cargo fmt --check
      - script: cargo clippy --all


### PR DESCRIPTION
Currently user specific setup steps are not run for linting jobs. This breaks crates that require, e.g., certain packages installed on the host.

Note: I am not sure if this PR builds or is correct, I just copied the lines from the main job ;)