### PR TITLE
Allow specifying clippy parameters

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -5,6 +5,7 @@ parameters:
   env: {}
   cross: true
   dir: "."
+  clippy: -D warnings
 
 jobs:
  - job: style
@@ -30,9 +31,9 @@ jobs:
      - script: cargo fmt --all -- --check
        workingDirectory: ${{ parameters.dir }}
        displayName: cargo fmt --check
-     - script: cargo clippy --all
+     - script: cargo clippy --all -- ${{ parameters.clippy }}
        workingDirectory: ${{ parameters.dir }}
-       displayName: cargo clippy -- -D warnings
+       displayName: cargo clippy -- ${{ parameters.clippy }}
  - job: main
    displayName: Compile and test
    dependsOn: []


### PR DESCRIPTION
Adds a parameter to `default.yml` to allow changing the clippy configuration, allowing/denying/etc lints.

Note: this changes the default behavior, unsure if it is intended. The `displayName` in `default.yml` was set to "cargo clippy -- -D warnings", but the actual command executed was "cargo clippy --all". This PR changes the script to actually run with `-D warnings` (denying warnings), but it can be overridden by the user of the template.

