### PR TITLE
Updated deprecated runners

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -16,7 +16,7 @@ jobs:
        beta:
          rust: beta
    pool:
-     vmImage: ubuntu-18.04
+     vmImage: ubuntu-22.04
    continueOnError: $[eq(variables.rust, 'beta')]
    steps:
      - template: install-rust.yml
@@ -40,16 +40,16 @@ jobs:
      strategy:
        matrix:
          "Linux (nightly)":
-           vmImage: ubuntu-18.04
+           vmImage: ubuntu-22.04
            rust: nightly
          "Linux (beta)":
-           vmImage: ubuntu-18.04
+           vmImage: ubuntu-22.04
            rust: beta
          Linux:
-           vmImage: ubuntu-18.04
+           vmImage: ubuntu-22.04
            rust: stable
          MacOS:
-           vmImage: macOS-10.15
+           vmImage: macOS-12
            rust: stable
          Windows:
            vmImage: windows-2019
@@ -58,13 +58,13 @@ jobs:
      strategy:
        matrix:
          "Linux (nightly)":
-           vmImage: ubuntu-18.04
+           vmImage: ubuntu-22.04
            rust: nightly
          "Linux (beta)":
-           vmImage: ubuntu-18.04
+           vmImage: ubuntu-22.04
            rust: beta
          Linux:
-           vmImage: ubuntu-18.04
+           vmImage: ubuntu-22.04
            rust: stable
    pool:
      vmImage: $(vmImage)
@@ -101,7 +101,7 @@ jobs:
      # This represents the minimum Rust version supported.
      # Tests are not run as tests may require newer versions of rust.
      pool:
-       vmImage: ubuntu-18.04
+       vmImage: ubuntu-22.04
      steps:
        - template: install-rust.yml
          parameters:


### PR DESCRIPTION
The Ubuntu and MacOS images cause warnings due to deprecation. For the ubuntu image there are also "scheduled brownouts" where the image can't be used in ADO.

https://github.com/actions/runner-images/issues/6002
https://github.com/actions/runner-images/issues/5583